### PR TITLE
Add new feature to auto-resolve version-related merge conflicts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 
 Synchronize and track all hardcoded versions in a project!
 Versions specified in .bumpversion.cfg are compared to those hosted in a baseline such as `origin/main`...
+Also auto-resolve version-related merge conflicts.
 
 ## User install
 ```bash

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -11,7 +11,7 @@
 #       bash integration-test.sh .venv/bin/python
 #
 PY=${1:-python}
-${PY} --version | grep -E '3\.(6|7|8|9|10|11|12|13)'
+${PY} --version | grep -E '3\.(9|10|11|12|13)'
 
 # need to have references for origin/main or master etc. for this to work...
 git fetch

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -37,7 +37,7 @@ echo "TEST SETUP"
 echo "Replacing whatever is in .git/hooks/pre-push with version checker"
 rm .git/hooks/pre-push
 version_checker -i pre-push || exit 1
-PREVBRANCH=$(git branch | grep -oE '\*.*' | grep -oE '[a-Z0-9]+')
+PREVBRANCH=$(git branch | grep -oE '\*.*' | grep -oE '[A-Za-z0-9]+')
 NUBRANCH=$(${PY} -c "import uuid; print(uuid.uuid4())")
 BASEBRANCH=origin/main
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     GitPython
     bump2version

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,11 @@ def create_mock_tree(in_files: str) -> tuple[git.Tree, git.Blob]:
 # endregion
 
 
+# region CheckerPath tests
+
+# endregion
+
+
 # region get_base_commit tests
 def test_get_base_commit_errors_for_bad_repo(mocker):
     patched_sys = mocker.patch.object(vc_utils, "sys")
@@ -120,28 +125,28 @@ def test_get_base_commit_errors_for_no_valid_base(mocker):
 # region get_bumpversion_config tests
 def test_get_bumpversion_config_handles_invalid_config():
     test_cfg_file = MALFORMATTED_CFG_FILE
-    files, regexes = vc_utils.get_bumpversion_config(cfg_file=test_cfg_file)
+    files, regexes = vc_utils.get_bumpversion_config(test_cfg_file)
     assert not files
     assert not regexes
 
 
 def test_get_bumpversion_config_handles_no_bumpversion_settings():
     test_cfg_file = NOSECTIONS_CFG_FILE
-    files, regexes = vc_utils.get_bumpversion_config(cfg_file=test_cfg_file)
+    files, regexes = vc_utils.get_bumpversion_config(test_cfg_file)
     assert not files
     assert not regexes
 
 
 def test_get_bumpversion_config_returns_nothing_if_no_files_detected():
     test_cfg_file = EMPTY_CFG_FILE
-    files, regexes = vc_utils.get_bumpversion_config(cfg_file=test_cfg_file)
+    files, regexes = vc_utils.get_bumpversion_config(test_cfg_file)
     assert not files
     assert not regexes
 
 
 def test_get_bumpversion_config_handles_valid_config():
-    test_cfg_file = VALID_CFG_FILE
-    files, regexes = vc_utils.get_bumpversion_config(cfg_file=test_cfg_file)
+    test_cfg_file = vc_utils.CheckerPath(".", VALID_CFG_FILE)
+    files, regexes = vc_utils.get_bumpversion_config(test_cfg_file)
 
     # verify we have files & regexes & match overall expected list size
     assert len(files) == len(KNOWN_FILE_DEFAULTS)
@@ -149,8 +154,9 @@ def test_get_bumpversion_config_handles_valid_config():
 
     # verify all files are accounted for, and the ones without 'search' are defaulted
     for f, r in zip(files, regexes):
-        assert f in KNOWN_FILE_DEFAULTS.keys()
-        if KNOWN_FILE_DEFAULTS[f]:
+        f_str = str(f)
+        assert f_str in KNOWN_FILE_DEFAULTS.keys()
+        if KNOWN_FILE_DEFAULTS[f_str]:
             assert r == _vc_version
         else:
             assert r != _vc_version
@@ -165,7 +171,7 @@ def test_search_commit_file_handles_invalid_file(mocker):
     commit_mock = mock.MagicMock(spec=git.Commit)
     commit_mock.tree.__truediv__.side_effect = KeyError("file not found")
 
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
 
     ret = vc_utils.search_commit_file(
         commit_mock, "fakefile", "fakesearch", abort=False
@@ -175,7 +181,7 @@ def test_search_commit_file_handles_invalid_file(mocker):
 
 
 def test_search_commit_file_handles_invalid_commit(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
 
     # wrong type, will raise attribute error
     ret = vc_utils.search_commit_file(
@@ -186,7 +192,7 @@ def test_search_commit_file_handles_invalid_commit(mocker):
 
 
 def test_search_commit_file_handles_text_not_found(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     patched__get = mocker.patch.object(vc_utils, "_get_commit_file")
     patched__get.return_value = "arbitrary text"
 
@@ -197,7 +203,7 @@ def test_search_commit_file_handles_text_not_found(mocker):
 
 
 def test_search_commit_file_handles_regex_fail_but_rawtext_match(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     patched__get = mocker.patch.object(vc_utils, "_get_commit_file")
     patched__get.return_value = "some content... no regex here[0-9]asdf!..."
 
@@ -208,7 +214,7 @@ def test_search_commit_file_handles_regex_fail_but_rawtext_match(mocker):
 
 
 def test_search_commit_file_handles_regex_success(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     patched__get = mocker.patch.object(vc_utils, "_get_commit_file")
     patched__get.return_value = "some content... regex me here123!..."
 
@@ -227,7 +233,7 @@ def test_install_hook_handles_vc_not_installed(mocker):
     patched_shutil.which.return_value = ""
 
     patched_os = mocker.patch.object(vc_utils, "os")
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
 
     vc_utils.install_hook("pre-push")
 
@@ -237,7 +243,7 @@ def test_install_hook_handles_vc_not_installed(mocker):
 
 def test_install_hook_handles_hook_already_exists(mocker):
     patched_shutil = mocker.patch.object(vc_utils, "shutil")
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     patched_os = mocker.patch.object(vc_utils, "os")
 
     patched_os.path.islink.return_value = True
@@ -250,7 +256,7 @@ def test_install_hook_handles_hook_already_exists(mocker):
 
 def test_install_hook_creates_link_if_dne(mocker):
     patched_shutil = mocker.patch.object(vc_utils, "shutil")
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     patched_os = mocker.patch.object(vc_utils, "os")
 
     patched_os.path.islink.return_value = False
@@ -308,7 +314,7 @@ def test_do_check_handles_empty_file_regex_list(mocker):
 
 def test_do_check_handles_file_not_changed(mocker):
     patched_sys = mocker.patch.object(vc_utils, "sys")
-    patched_ok = mocker.patch.object(vc_utils, "_ok")
+    patched_ok = mocker.patch.object(vc_utils, "ok")
     base_commit_mock = mock.MagicMock(spec=git.Commit)
     current_commit_mock = mock.MagicMock(spec=git.Commit)
     files = ["version.txt"]
@@ -336,7 +342,7 @@ def test_do_check_handles_file_changed_but_no_version_change(mocker):
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver]
 
-    files = ["version.txt"]
+    files = [vc_utils.CheckerPath(".", "version.txt")]
     file_regexes = [_vc_version]
 
     fake_tree, blob_mock = create_mock_tree(["version.txt"])
@@ -366,7 +372,7 @@ def test_do_check_handles_release_and_build_number_addition(mocker):
     old_ver = "0.0.0"
     new_ver = "0.0.1-alpha.0"
 
-    patched_ok = mocker.patch.object(vc_utils, "_ok")
+    patched_ok = mocker.patch.object(vc_utils, "ok")
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver]
 
@@ -397,8 +403,8 @@ def test_do_check_detects_other_file_mismatch(mocker):
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver, other_file_ver]
 
-    files = ["version.txt", "some_other_file.txt"]
-    file_regexes = [_vc_version]
+    files = [vc_utils.CheckerPath(".", "version.txt"), vc_utils.CheckerPath(".", "some_other_file.txt")]
+    file_regexes = [_vc_version, _vc_version]
 
     patched_log = mocker.patch.object(vc_utils, "LOG")
 
@@ -430,12 +436,12 @@ def test_do_check_verifies_all_version_changes(mocker):
     other_file_ver = new_ver
     other_file_ver2 = new_ver
 
-    patched_ok = mocker.patch.object(vc_utils, "_ok")
+    patched_ok = mocker.patch.object(vc_utils, "ok")
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver, other_file_ver, other_file_ver2]
 
-    files = ["version.txt", "some_other_file.txt", "some_other_file2.txt"]
-    file_regexes = [_vc_version]
+    files = [vc_utils.CheckerPath(".", "version.txt"), vc_utils.CheckerPath(".", "some_other_file.txt"), vc_utils.CheckerPath(".", "some_other_file2.txt")]
+    file_regexes = [_vc_version, _vc_version, _vc_version]
 
     fake_tree, blob_mock = create_mock_tree(["version.txt"])
     base_commit_mock.tree = fake_tree
@@ -458,11 +464,11 @@ def test_do_check_handles_new_file(mocker):
     old_ver = "0.0.1"
     new_ver = "0.0.2"
 
-    patched_ok = mocker.patch.object(vc_utils, "_ok")
+    patched_ok = mocker.patch.object(vc_utils, "ok")
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver]
 
-    files = ["version.txt"]
+    files = [vc_utils.CheckerPath(".", "version.txt")]
     file_regexes = [_vc_version, _vc_version]
 
     fake_current_tree, fake_blob = create_mock_tree(["version.txt"])
@@ -491,7 +497,7 @@ def test_do_check_errors_for_file_not_in_current_tree(mocker):
 
     patched_log = mocker.patch.object(vc_utils, "LOG")
 
-    files = ["file-should-not-be-found-version.txt"]
+    files = [vc_utils.CheckerPath(".", "file-should-not-be-found-version.txt")]
     file_regexes = [_vc_version, _vc_version]
 
     fake_tree, fake_blob = create_mock_tree(["version.txt"])
@@ -518,11 +524,11 @@ def test_do_check_handles_bad_new_version(mocker):
     )
 
     patched_log = mocker.patch.object(vc_utils, "LOG")
-    patched_ok = mocker.patch.object(vc_utils, "_ok")
+    patched_ok = mocker.patch.object(vc_utils, "ok")
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [new_ver]
 
-    files = ["version.txt"]
+    files = [vc_utils.CheckerPath(".", "version.txt")]
     file_regexes = [_vc_version]
 
     fake_current_tree, fake_blob = create_mock_tree(["version.txt"])
@@ -556,7 +562,7 @@ def test_do_check_handles_new_version_less_than_old_version(mocker):
     patched_search = mocker.patch.object(vc_utils, "search_commit_file")
     patched_search.side_effect = [old_ver, new_ver]
 
-    files = ["version.txt"]
+    files = [vc_utils.CheckerPath(".", "version.txt")]
     file_regexes = [_vc_version]
 
     fake_tree, blob_mock = create_mock_tree(["version.txt"])
@@ -579,7 +585,7 @@ def test_do_check_handles_new_version_less_than_old_version(mocker):
 
 
 def test_compare_versions_returns_false_for_invalid_new_version(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     old_ver = "0.0.1"
     new_ver = "not a version"
     assert not vc_utils.compare_versions(old_ver, new_ver, abort=False)
@@ -587,7 +593,7 @@ def test_compare_versions_returns_false_for_invalid_new_version(mocker):
 
 
 def test_compare_versions_returns_false_for_new_version_less_than_old(mocker):
-    patched_err = mocker.patch.object(vc_utils, "_error")
+    patched_err = mocker.patch.object(vc_utils, "error")
     old_ver = "0.0.2"
     new_ver = "0.0.1"
     assert not vc_utils.compare_versions(old_ver, new_ver, abort=False)

--- a/version_checker/Readme.md
+++ b/version_checker/Readme.md
@@ -62,6 +62,10 @@ version_checker -i pre-push
 # the errors should tell you to do something like the following
 bump2version patch
 bump2version --help
+
+# given an ongoing merge conflict of versions, run the following to auto-resolve
+# keeping the higher of the two versions
+version_checker --merge
 ```
 
 ## environment variables

--- a/version_checker/constants.py
+++ b/version_checker/constants.py
@@ -3,7 +3,9 @@ version_checker constants
 
 Defaults and globals to be used by version checker software
 '''
+from enum import Enum
 import os
+import re
 
 
 # pylint: disable=bad-option-value,unnecessary-lambda-assignment
@@ -43,3 +45,23 @@ with open(os.path.join(
 README_CONTENTS = ''
 with open(os.path.join(LIB_LOC, SUBDIR, 'Readme.md'), 'r', encoding='utf-8') as _f:
     README_CONTENTS = _f.read()
+
+class MergeStrategy(Enum):
+    """Enum for possible merge strategies when resolving merge conflicts"""
+    HIGHER="higher"
+    LOWER="lower"
+    CURRENT="current"
+    INCOMING="incoming"
+    BOTH="both"
+    NEITHER="neither"
+
+CONFLICT_RE = re.compile(
+    r"""
+    (?P<start>^<<<<<<<[^\n]*\n)
+    (?P<current>.*?)
+    ^=======\n
+    (?P<incoming>.*?)
+    (?P<end>^>>>>>>>[^\n]*\n?)
+    """,
+    re.MULTILINE | re.DOTALL | re.VERBOSE,
+)

--- a/version_checker/merge_utils.py
+++ b/version_checker/merge_utils.py
@@ -1,0 +1,266 @@
+'''
+Utils for version checker merge conflict resolution
+
+Contains common public-exposed functions for cli to use etc.
+'''
+from dataclasses import dataclass
+import logging
+import os
+import re
+
+from git import Commit, Repo
+
+from version_checker.constants import CONFLICT_RE, LOG_NAME, MergeStrategy
+from version_checker.utils import (
+    CheckerPath,
+    error,
+    ok,
+    parse_versions_from_version_file,
+    compare_versions,
+)
+
+
+LOG = logging.getLogger(LOG_NAME)
+
+
+@dataclass
+class VersionFile:
+    """Dataclass for storing file path and corresponding regexes for current and incoming commits"""
+    path: CheckerPath
+    current_regex: str
+    incoming_regex: str
+
+
+@dataclass
+class MergeConflict:
+    """Dataclass for merge conflict information with utilities for resolving them"""
+    start_index: int
+    end_index: int
+    start_line: str
+    end_line: str
+    current: str
+    incoming: str
+    text: str
+
+    @classmethod
+    def from_regex_match(cls, match: re.Match[str]) -> "MergeConflict":
+        """Generate MergeConflict from regex match (see constants.py)"""
+        return MergeConflict(
+            start_index=match.start(),
+            end_index=match.end(),
+            start_line=match.group("start"),
+            end_line=match.group("end"),
+            current=match.group("current"),
+            incoming=match.group("incoming"),
+            text=match.group(0),
+        )
+
+    def get_merge_result(self, merge_strategy: MergeStrategy = None) -> str:
+        """Get simple merge result given a merge strategy"""
+        return self._get_merge_result(
+            self.current, self.incoming, self.text, merge_strategy
+        )
+
+    def get_split_merge_result(
+        self, merge_splits: list[tuple[str, str]], merge_strategy: MergeStrategy = None
+    ) -> str:
+        """Get merge result given a merge strategy and a list text sections (current and incoming) 
+        from within the merge conflict that may split the merge conflict into multiple conflicts"""
+        result = ""
+        current = self.current
+        incoming = self.incoming
+        for current_split, incoming_split in merge_splits:
+            try:
+                current_parsed, current = current.split(current_split, 1)
+                incoming_parsed, incoming = incoming.split(incoming_split, 1)
+            except ValueError:
+                LOG.warning("Unable to find given text within given merge conflict" \
+                " - skipping conflict resolution")
+                return self.text
+            if (
+                self._is_invalid_line(current_parsed)
+                or self._is_invalid_line(incoming_parsed)
+                or self._is_invalid_line(current_split)
+                or self._is_invalid_line(incoming_split)
+            ):
+                LOG.warning("Given text does not break up merge conflict into complete lines" \
+                " - skipping conflict resolution")
+                return self.text
+
+            result += self._create_conflict_text(current_parsed, incoming_parsed)
+            result += self._get_merge_result(
+                current_split,
+                incoming_split,
+                self._create_conflict_text(current_split, incoming_split),
+                merge_strategy,
+            )
+        result += self._create_conflict_text(current, incoming)
+
+        return result
+
+    def apply_merge(self, file_text: str, merge_result: str) -> str:
+        """Apply a merge result to file text (given start/end indices of the original merge 
+        conflict)"""
+        LOG.debug("Applying merge resolution, replacing:\n%swith:\n%s", self.text, merge_result)
+        return (
+            file_text[: self.start_index] + merge_result + file_text[self.end_index :]
+        )
+
+    def _create_conflict_text(self, current: str, incoming: str) -> str:
+        """Create a new merge conflict section"""
+        if current == "" and incoming == "":
+            return ""
+        return self.start_line + current + "=======\n" + incoming + self.end_line
+
+    def _get_merge_result(
+        self,
+        current: str,
+        incoming: str,
+        default: str,
+        merge_strategy: MergeStrategy = None,
+    ) -> str:
+        """Get the result of a merge conflict given current/incoming text"""
+        if merge_strategy == MergeStrategy.CURRENT:
+            return current
+        if merge_strategy == MergeStrategy.INCOMING:
+            return incoming
+        if merge_strategy == MergeStrategy.BOTH:
+            return current + incoming
+        if merge_strategy == MergeStrategy.NEITHER:
+            return ""
+        return default
+
+    def _is_invalid_line(self, text: str) -> bool:
+        """Does this text end on a newline"""
+        return text != "" and not text.endswith("\n")
+
+
+def do_merge(
+    current_commit: Commit,
+    files: list[CheckerPath],
+    file_regexes: list[str],
+    merge_strategy: MergeStrategy,
+):
+    """Apply merge strategy for version conflicts given a list of files/version regexes"""
+    LOG.debug(
+        '%s, %s, %s, %s', str(current_commit), str(files), str(file_regexes), merge_strategy.value)
+
+    repo = current_commit.repo
+
+    conflicted_files = set(repo.index.unmerged_blobs().keys())
+    if len(conflicted_files) == 0:
+        ok("No merge conflicts detected")
+        return
+
+    if not files or not file_regexes:
+        error('No files or regexes provided!', abort=True)
+        return
+
+    incoming_commit = repo.commit(repo.git.rev_parse("--verify", "MERGE_HEAD"))
+
+    incoming_version, current_version = parse_versions_from_version_file(
+        incoming_commit, current_commit, files[0].repo_path, file_regexes[0]
+    )
+
+    if merge_strategy in {MergeStrategy.HIGHER, MergeStrategy.LOWER}:
+        is_current_bigger = compare_versions(incoming_version, current_version)
+        should_merge_current = (
+            is_current_bigger and merge_strategy == MergeStrategy.HIGHER
+        ) or (not is_current_bigger and merge_strategy == MergeStrategy.LOWER)
+        merge_strategy = (
+            MergeStrategy.CURRENT if should_merge_current else MergeStrategy.INCOMING
+        )
+    LOG.info('Resolving version conflicts using "%s" merge strategy', merge_strategy.value)
+
+    conflicted_version_files = [
+        VersionFile(
+            file,
+            file_regex,
+            file_regex.replace(current_version, incoming_version, 1),
+        )
+        for file, file_regex in zip(files, file_regexes)
+        if file.repo_path in conflicted_files
+    ]
+    LOG.debug('Resolving the following version file conflicts: %s', conflicted_version_files)
+
+    for version_file in conflicted_version_files:
+        resolve_version_conflicts(version_file, merge_strategy, repo)
+
+    ok("Resolved all version merge conflicts that could be auto-resolved." \
+    " Verify changes for errors or failed resolutions before committing")
+
+    return
+
+
+def resolve_version_conflicts(
+    version_file: VersionFile, merge_strategy: MergeStrategy, repo: Repo
+):
+    """Resolve version conflicts for a specific version file
+
+    FTODO: Doesn't yet auto-resolve conflicts caused by deleted/added version files
+    """
+    if not os.path.exists(version_file.path) or not os.path.isfile(version_file.path):
+        error(f"Version file {version_file.path} does not exist", abort=False)
+        return
+
+    LOG.info("Resolving conflicts for version file: %s", version_file)
+
+    with open(version_file.path, "r", encoding="utf-8") as file:
+        file_text = file.read()
+
+    conflicts = parse_merge_conflicts(file_text)
+    for conflict in reversed(conflicts):
+        version_conflict_lines = parse_version_conflict_lines(version_file, conflict)
+        if len(version_conflict_lines) > 0:
+            merge_result = conflict.get_split_merge_result(
+                version_conflict_lines, merge_strategy
+            )
+            file_text = conflict.apply_merge(file_text, merge_result)
+
+    with open(version_file.path, "w", encoding="utf-8") as file:
+        file.write(file_text)
+
+    conflicts = parse_merge_conflicts(file_text)
+    if not conflicts:
+        LOG.debug(
+            "All conflicts resolved for version file %s - adding to merge commit",
+            version_file.path,
+        )
+        repo.git.restore("--staged", version_file.path.repo_path)
+        repo.index.add([version_file.path.repo_path])
+
+
+def parse_merge_conflicts(file_text: str) -> list[MergeConflict]:
+    """Parse all merge conflicts in file"""
+    return [
+        MergeConflict.from_regex_match(match)
+        for match in CONFLICT_RE.finditer(file_text)
+    ]
+
+
+def parse_version_conflict_lines(
+    version_file: VersionFile, conflict: MergeConflict
+) -> list[tuple[str, str]]:
+    """Parse version conflict lines from a merge conflict"""
+    current_version_lines = [
+        line
+        for line in conflict.current.splitlines(keepends=True)
+        if is_regex_match(version_file.current_regex, line)
+    ]
+    incoming__version_lines = [
+        line
+        for line in conflict.incoming.splitlines(keepends=True)
+        if is_regex_match(version_file.incoming_regex, line)
+    ]
+
+    if len(current_version_lines) != len(incoming__version_lines):
+        LOG.warning("Found different number of version matches in merge conflict for current" \
+        " commit vs incoming commit. Defaulting to smaller length." \
+        " Verify changes before committing.")
+
+    return list(zip(current_version_lines, incoming__version_lines))
+
+
+def is_regex_match(regex_str: str, search_str: str) -> bool:
+    """Checks if a given regex string matches (or is within) a given search string"""
+    return re.search(regex_str, search_str) or regex_str in search_str

--- a/version_checker/utils.py
+++ b/version_checker/utils.py
@@ -36,7 +36,7 @@ class CheckerPath:
     @property
     def abs_path(self):
         """The absolute path of the given file"""
-        return self.abs_path
+        return self._abs_path
 
     @property
     def cwd_path(self):

--- a/version_checker/utils.py
+++ b/version_checker/utils.py
@@ -216,7 +216,7 @@ def install_hook(hook):
         ok(f'"{prog_path}", installed to "{hook_path}"')
 
 
-def get_bumpversion_config(config_file: CheckerPath, commit: Commit | None = None):
+def get_bumpversion_config(config_file: CheckerPath, commit: Commit = None):
     """Helper to parse bumpversion configurations from config file
 
     returns parsed file, file regexes


### PR DESCRIPTION
Run `version_checker --merge` anytime you merge another branch in a way that causes version merge conflicts. By default this will select the higher version (this can be configured but is probably what you want 99+% of the time). 

To test, create a test branch. From there, create another branch. Bump the version once and commit. Switch back to the previous test branch. Bump the version twice and commit. Merge the second branch into the first. This will result in merge conflicts. It may be necessary to manually resolve version conflicts in python files (__init__.py and cli.py) since merge conflicts in these files prevent the version_checker script from running in the first place. Then run `version_checker --merge`. Review that the changes look correct. Run `git merge --abort` to reset if you want to test different scenarios. Another scenario to test would be, after starting the merge, adding some text with the current/incoming sections of the various merge conflicts. Then noticing that `version_checker --merge` will merge the version lines and split the surrounding lines into separate merge conflicts.

There were some minor changes to existing code that doesn't change behavior (moving some things around in cli.py and unprotecting some functions in utils.py). This also sets the minimum supported python version based on what github actions tests. 

Note: Missing unit/integration tests for the merge stuff. And CICD is failing due to permissions issue.
